### PR TITLE
Clean job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@
 /node_modules
 /docker-compose/nginx/public/*
 !/docker-compose/nginx/public/.gitkeep
+
+# Ignore doc and yard tmp
+/.yardoc
+/doc

--- a/app/jobs/clean_job.rb
+++ b/app/jobs/clean_job.rb
@@ -1,0 +1,20 @@
+# This job remove {Happening}s and {Ticket}s expired from an arbitrary days number.
+# Remove old data is required to grant the user privacy
+class CleanJob < ApplicationJob
+  queue_as :default
+
+  # On perform, expired {Happening}s from an arbitrary days number are destroyed.
+  # On destroy each [Happening] destroy relative [Ticket]s
+  # 
+  # @param days [Integer,Nil] destroy {Happening} exired from :days
+  # @return [ARRAY] of destroyed happenings
+  # @return [NIL] if :days isn't defined, return nil and anyting is destroyed
+  # @example destroy {Happening} expired from 60 days
+  #   CleanJob.perform_now(days: 60)
+  # @example destroy anyting
+  #   CleanJob.perform_now
+  #   CleanJob.perform_now(days: nil)
+  def perform(days: nil)
+    Happening.where(start_at: [..Time.zone.now.to_date - days.to_i]).destroy_all if days.present?
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,9 +1,10 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
+production:
+  periodic_cleanup:
+    class: CleanSoftDeletedRecordsJob
+    queue: background
+    args:
+      days: ENV.fetch("RAILS_CLEAN_AFTER_DAYS", nil).to_i
+    schedule: "0 2 * * *"
 #   periodic_command:
 #     command: "SoftDeletedRecord.due.delete_all"
 #     priority: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ x-rails_conf: &rails_conf
   RAILS_DESCRIPTION: Partecipo description
   RAILS_HEAD_URL: /head.html
   RAILS_FOOTER_URL: /footer.html
+  ### RAILS_CLEAN_AFTER_DAYS, destroy old happening and ticket after this number of days. If nil isn't removed anything
+  RAILS_CLEAN_AFTER_DAYS: 60
   ### RAILS_PORT, port used for generate oidc url, use 80 for localhost demo, 443 on production
   RAILS_PORT: 80
   ### RAILS_SCHEME, Scheme user for generate oidc url, use "http" for localhost demo, "https" on production

--- a/test/jobs/clean_job_test.rb
+++ b/test/jobs/clean_job_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class CleanJobTest < ActiveJob::TestCase
+  test "remove expired expired from happening and ticket" do
+    (0..3).each do |h|
+      happening = create :happening, start_at: Time.zone.now - h.days
+      (0..3).each do |t|
+        create :ticket, happening:, by_editor: true
+      end
+    end
+    assert_equal Ticket.count, 16
+    perform_enqueued_jobs do
+      CleanJob.perform_later(days: 2)
+    end
+    assert_equal Ticket.count, 12
+  end
+end


### PR DESCRIPTION
Remove old data is required to grant the user privacy
[CleanJob](https://github.com/isprambiente/Partecipo/blob/clean_happening/app/jobs/clean_job.rb) remove automatically Happenings and Tickets expired from an arbitrary days number. 
CleanJob is executed [every day at 01:00 AM](https://github.com/isprambiente/Partecipo/blob/clean_happening/config/recurring.yml), the nuber of dayis defined with [RAILS_CLEAN_AFTER_DAYS](https://github.com/isprambiente/Partecipo/blob/clean_happening/docker-compose.yml) environment. If RAILS_CLEAN_AFTER_DAYS env is not defined, nothing is deleted.

## Example
destroy Happening expired from 60 days
```
CleanJob.perform_now(days: 60)
```
destroy nothing
```
CleanJob.perform_now
CleanJob.perform_now(days: nil)
```
