### PR TITLE
103 aggiungere tipi di domande integer e data

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
+ARG RUBY_VERSION=3.3.5
+FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,36 @@
+name: "rails_app"
+
+services:
+  rails-app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+    - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    depends_on:
+    - selenium
+    - redis
+
+  selenium:
+    image: selenium/standalone-chromium
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.2
+    restart: unless-stopped
+    volumes:
+    - redis-data:/data
+
+  
+volumes:
+  redis-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+  "name": "rails_app",
+  "dockerComposeFile": "compose.yaml",
+  "service": "rails-app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rails/devcontainer/features/activestorage": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/rails/devcontainer/features/sqlite3": {}
+  },
+
+  "containerEnv": {
+    "CAPYBARA_SERVER_PORT": "45678",
+    "SELENIUM_HOST": "selenium",
+    "REDIS_URL": "redis://redis:6379/1",
+    "KAMAL_REGISTRY_PASSWORD": "$KAMAL_REGISTRY_PASSWORD"
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000, 6379],
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
+  // "remoteUser": "root",
+
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "bin/setup --skip-server"
+}

--- a/app/components/answers/sub_form_component.html.haml
+++ b/app/components/answers/sub_form_component.html.haml
@@ -12,4 +12,10 @@
           = @form.text_area :value, class: 'textarea', required: @form.object.question_mandatory?
         - when 'select'
           .select.is-fullwidth= @form.select :value, @form.object.question.options.map(&:title), {}, required: @form.object.question_mandatory?
+        - when 'file'
+          = @form.file_field :file, class: 'input', required: @form.object.question_mandatory?
+        - when 'number'
+          = @form.number_field :value, class: 'input', required: @form.object.question_mandatory?
+        - when 'date'
+          = @form.date_field :value, class: 'input', required: @form.object.question_mandatory?
 

--- a/app/components/tickets/ticket_component.html.haml
+++ b/app/components/tickets/ticket_component.html.haml
@@ -14,7 +14,9 @@
       - @ticket.answers.each do |answer|
         %tr
           %th.is-size-7.is-narrow= answer.question.title
-          %td.is-size-7= answer.value
+          %td.is-size-7
+            = answer.value
+            = link_to  answer.file.filename, rails_blob_path(answer.file, disposition: "attachment") if answer.file.present?
   .list-item-controls
     .buttons.is-right
       %button.button{data: {action: 'details#toggle', _to: dom_id(@ticket, 'detail')}}= icon "fas fa-maximize"

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -55,6 +55,6 @@ class TicketsController < ApplicationController
 
   # filter params for {Happening}'s {Ticket}
   def ticket_params
-    params.fetch(:ticket, {}).permit(:happening_id, answers_attributes: [ :question_id, :value ])
+    params.fetch(:ticket, {}).permit(:happening_id, answers_attributes: [ :question_id, :value, :file ])
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -36,7 +36,7 @@ class Question < ApplicationRecord
 
   accepts_nested_attributes_for :options, allow_destroy: true, reject_if: :all_blank
 
-  enum :category, %i[string text select file], prefix: true
+  enum :category, %i[string text select file number date], prefix: true
 
   validates :title, presence: true
   validates :weight, presence: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,9 +19,13 @@ t1 = Template.create title: 'Generalità utente', data: [
   { title: 'Cognome', mandatory: true, weight: 2 }
 ]
 t2 = Template.create title: 'Generalità con dettagli', data: [
-  { title: 'Nome', mandatory: true, weight: 3 },
-  { title: 'Cognome', mandatory: true, weight: 2 },
-  { title: 'Ente o società', mandatory: false, weight: 1 },
+  { title: 'Ente o società', mandatory: false, weight: 8 },
+  { title: 'Nome', mandatory: true, weight: 7 },
+  { title: 'Cognome', mandatory: true, weight: 6 },
+  { title: 'Anni di esperienza', mandatory: true, weight: 5, category: :number},
+  { title: 'Data di nascita', mandatory: true, weight: 4, category: :date},
+  { title: 'Raccontaci di te', mandatory: true, weight: 3, category: :text}, 
+  { title: 'Foto', mandatory: true, weight: 2, category: :file},
   { title: 'tipologia', category: :select, mandatory: true, weight: 1, options_attributes: [
     { title: 'Dirigente pubblico', acceptable: true, weight: 4 },
     { title: 'Dipendente pubblico', acceptable: true, weight: 3 },

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,5 +3,14 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ]
+  if ENV["CAPYBARA_SERVER_PORT"]
+    served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
+
+    driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
+      browser: :remote,
+      url: "http://#{ENV["SELENIUM_HOST"]}:4444"
+    }
+  else
+    driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  end
 end


### PR DESCRIPTION
Aggiunte le tipologie di domande che ora diventano:
| Tipo | Chiave | Note |
| ------------- | -------- | ---
| Testo breve | string    | default, text field 
| Testo lungo | text       | text area 
| Selezione    | select    | select field 
| Ddata          | date      | date field 
| Numeri       | number | number field 
| File             | file         | file field 

Esteso il template "Generalità con dettaglio" per includere tipologie di domande differenti come il campo testo, data, numeri e file.
 In questo modo gli utenti hanno un esempio da copiare per creare i nuovi template.
 ```yaml
[
  {"title":"Ente o società","weight":8,"mandatory":false},
  {"title":"Nome","weight":7,"mandatory":true},
  {"title":"Cognome","weight":6,"mandatory":true},
  {"title":"Età","weight":5,"category":"number","mandatory":true},
  {"title":"Data di nascita","weight":4,"category":"date","mandatory":true},
  {"title":"Raccontaci di te","weight":3,"category":"text","mandatory":true},
  {"title":"Foto","weight":2,"category":"file","mandatory":true},
  {"title":"tipologia","weight":1,"category":"select","mandatory":true,"options_attributes": [
    {"title":"Dirigente pubblico","weight":4,"acceptable":true},
    {"title":"Dipendente pubblico","weight":3,"acceptable":true},
    {"title":"Società privata","weight":2,"acceptable":true},
    {"title":"Docente universitario","weight":1,"acceptable":true},
    {"title":"Altro, non dichiarato","weight":0,"acceptable":true}
  ]}
]
 ```

@mspasiano , un regalo per te: ho aggiunto i [devcontainer](https://containers.dev/) per [Rails](https://github.com/rails/devcontainer)  così ti puoi creare facilmente un  ambiente di sviluppo conteinerizzato 